### PR TITLE
Missing file quasar.esm.js added

### DIFF
--- a/dist/quasar.esm.js
+++ b/dist/quasar.esm.js
@@ -1,0 +1,4 @@
+import Quasar from './quasar.mat.esm.js'
+
+export * from './quasar.mat.esm.js'
+export default Quasar


### PR DESCRIPTION
Will export `quasar.mat.esm.js` exports as default.

This file is mentioned in package.json but does not exist
Used this to successfully install v0.15